### PR TITLE
Fix bug where Furnace Generator consumes Blood Magic Lava Crystal

### DIFF
--- a/src/main/scala/com/dyonovan/neotech/common/tiles/machines/generators/TileFurnaceGenerator.scala
+++ b/src/main/scala/com/dyonovan/neotech/common/tiles/machines/generators/TileFurnaceGenerator.scala
@@ -84,7 +84,10 @@ class TileFurnaceGenerator extends MachineGenerator with FluidHandler {
                 burnTime = TileEntityFurnace.getItemBurnTime(getStackInSlot(INPUT_SLOT))
 
                 if (burnTime > 0) {
-                    getStackInSlot(INPUT_SLOT).stackSize -= 1
+                    if (getStackInSlot(INPUT_SLOT).getItem().getContainerItem(getStackInSlot(INPUT_SLOT)) == null)
+                        getStackInSlot(INPUT_SLOT).stackSize -= 1
+                    else
+                        setInventorySlotContents(INPUT_SLOT, getStackInSlot(INPUT_SLOT).getItem().getContainerItem(getStackInSlot(INPUT_SLOT)))
                     if (getStackInSlot(INPUT_SLOT).stackSize <= 0)
                         setInventorySlotContents(INPUT_SLOT, null)
                     currentObjectBurnTime = burnTime


### PR DESCRIPTION
#308

Looked at Furnus to see how it dealt with container items and came up with this. I assume that this wasn't a test case because buckets are not allowed to be used in the Furnace Generator. But as the Lava Crystal is a solid fuel and doesn't work in the Fluid Generator, I thought this would be a good fix.
